### PR TITLE
RPBE, DFT-D3, and Min algo for static calculations

### DIFF
--- a/atomate/vasp/firetasks/adsorption_tasks.py
+++ b/atomate/vasp/firetasks/adsorption_tasks.py
@@ -681,7 +681,8 @@ class GenerateSlabAdsTask(FiretaskBase):
                     "LREAL": False,
                     "LASPH": True,
                     "LORBIT": 11,
-                    "LELF": True
+                    "LELF": True,
+                    "IVDW":11
                 }
 
         if static_input_set is False:

--- a/atomate/vasp/firetasks/adsorption_tasks.py
+++ b/atomate/vasp/firetasks/adsorption_tasks.py
@@ -211,6 +211,11 @@ class AnalyzeStaticOptimumDistance(FiretaskBase):
             #Lowest value of fit:
             lowest_energy = min(yd)
             optimal_distance = xd[np.where(yd == yd.min())[0]]
+        elif algo == "minimum":
+            import numpy as np
+            all_energies = np.array(all_energies)
+            lowest_energy = min(all_energies)
+            optimal_distance = all_distances[np.where(all_energies == all_energies.min())[0][0]]
 
         #Optimal Energy for current slab with adsorbate:
         if slab_ads_struct:
@@ -682,7 +687,8 @@ class GenerateSlabAdsTask(FiretaskBase):
                     "LASPH": True,
                     "LORBIT": 11,
                     "LELF": True,
-                    "IVDW":11
+                    "IVDW":11,
+                    "GGA":"RP"
                 }
 
         if static_input_set is False:

--- a/atomate/vasp/fireworks/adsorption.py
+++ b/atomate/vasp/fireworks/adsorption.py
@@ -251,7 +251,7 @@ class BulkFW(Firework):
         import atomate.vasp.firetasks.adsorption_tasks as at
 
         user_incar_settings = (user_incar_settings
-                               or {'IBRION': 2, 'POTIM': 0.5, 'NSW': 200, "IVDW":11})
+                               or {'IBRION': 2, 'POTIM': 0.5, 'NSW': 200, "IVDW":11, "GGA":"RP"})
         vis = vasp_input_set or MPSurfaceSet(
             bulk_structure, bulk=True, user_incar_settings=user_incar_settings)
 
@@ -421,7 +421,7 @@ class SlabFW(Firework):
         import atomate.vasp.firetasks.adsorption_tasks as at
 
         user_incar_settings = (user_incar_settings
-                               or {'IBRION': 2, 'POTIM': 0.5, 'NSW': 200})
+                               or {'IBRION': 2, 'POTIM': 0.5, 'NSW': 200, "GGA":RP})
         vis = vasp_input_set or MPSurfaceSet(
             slab_structure, bulk=False,
             user_incar_settings=user_incar_settings)
@@ -605,7 +605,7 @@ class SlabAdsFW(Firework):
         import atomate.vasp.firetasks.adsorption_tasks as at
 
         user_incar_settings = (user_incar_settings
-                               or {'IBRION': 2, 'POTIM': 0.5, 'NSW': 200, "IVDW":11})
+                               or {'IBRION': 2, 'POTIM': 0.5, 'NSW': 200, "IVDW":11,"GGA":"RP"})
         vis = vasp_input_set or MPSurfaceSet(
             slab_ads_structure, bulk=False,
             user_incar_settings=user_incar_settings)

--- a/atomate/vasp/fireworks/adsorption.py
+++ b/atomate/vasp/fireworks/adsorption.py
@@ -251,7 +251,7 @@ class BulkFW(Firework):
         import atomate.vasp.firetasks.adsorption_tasks as at
 
         user_incar_settings = (user_incar_settings
-                               or {'IBRION': 2, 'POTIM': 0.5, 'NSW': 200})
+                               or {'IBRION': 2, 'POTIM': 0.5, 'NSW': 200, "IVDW":11})
         vis = vasp_input_set or MPSurfaceSet(
             bulk_structure, bulk=True, user_incar_settings=user_incar_settings)
 
@@ -605,7 +605,7 @@ class SlabAdsFW(Firework):
         import atomate.vasp.firetasks.adsorption_tasks as at
 
         user_incar_settings = (user_incar_settings
-                               or {'IBRION': 2, 'POTIM': 0.5, 'NSW': 200})
+                               or {'IBRION': 2, 'POTIM': 0.5, 'NSW': 200, "IVDW":11})
         vis = vasp_input_set or MPSurfaceSet(
             slab_ads_structure, bulk=False,
             user_incar_settings=user_incar_settings)


### PR DESCRIPTION
## SUMMARY
* Added IVDW=11 (DFT-D3) method for dispersion correction for slab and slab+ads
* Added GGA = RP for RPBE functional for more accurate results (https://aip.scitation.org/doi/pdf/10.1063/1.3382342)
* Added algo="minimum" option for static tests to just pick the smallest energy distance and not do any fits.