### PR TITLE
Fixes

### DIFF
--- a/atomate/vasp/firetasks/adsorption_tasks.py
+++ b/atomate/vasp/firetasks/adsorption_tasks.py
@@ -549,8 +549,11 @@ class SlabAdsAdditionTask(FiretaskBase):
         fws = []
 
         print("load data")
+        try:
+            output_slab = Structure.from_dict(fw_spec["slab_structure"])
+        except:
+            output_slab = fw_spec["slab_structure"]
 
-        output_slab = Structure.from_dict(fw_spec["slab_structure"])
         slab_energy = fw_spec["slab_energy"]
         calc_locs = fw_spec["calc_locs"]
         slab_dir = None

--- a/atomate/vasp/firetasks/adsorption_tasks.py
+++ b/atomate/vasp/firetasks/adsorption_tasks.py
@@ -717,7 +717,8 @@ class SlabAdsAdditionTask(FiretaskBase):
                     ba = BaderAnalysis(chgcar_file, potcar_file)
                     bader_charges = {"surface": {}}
                     # Bader for Surface
-                    for surf_idx, surf_prop in surface_sites.items():
+                    for surf_idx, surf_prop in enumerate(
+                            surface_sites.items()):
                         idx = surf_prop["index"]
                         bader_charges["surface"][surf_idx] = \
                             ba.get_charge(idx)


### PR DESCRIPTION
## Summary
Merged with your edits, fixes for surface sites for bader analysis and change to relaxation runs:

Since the SlabSet choses ISIF=2, the cell size/shape doesn't change - so its not necessary to run a double relaxation relaxation for both slab/slab+ads. Additionally, we use the relaxed bulk structure for our slabs - so we should only run a "normal" job_type for OptimizeFW.