### PR TITLE
IVDW=11 for slab

### DIFF
--- a/atomate/vasp/fireworks/adsorption.py
+++ b/atomate/vasp/fireworks/adsorption.py
@@ -337,7 +337,7 @@ class SlabFW(Firework):
         user_incar_settings = (user_incar_settings
                                or {'IBRION': 2, 'POTIM': 0.5, 'NSW': 300,
                                    "IMIX": 4, "ALGO": "Fast", "LREAL": True,
-                                   "GGA": "RP"})
+                                   "GGA": "RP","IVDW":11})
         vis = vasp_input_set or MPSurfaceSet(
             slab_structure, bulk=False,
             user_incar_settings=user_incar_settings)


### PR DESCRIPTION
## Summary
Forgot IVDW=11 for slab. For all energies to be comparable, we should use IVDW11 across the board.