### PR TITLE
FakeVasp on Previous Calculated at WF Level

### DIFF
--- a/atomate/vasp/firetasks/adsorption_tasks.py
+++ b/atomate/vasp/firetasks/adsorption_tasks.py
@@ -457,7 +457,7 @@ class SlabAdditionTask(FiretaskBase):
             if getattr(slab, "miller_index", None):
                 name += "_{}".format(slab.miller_index)
             if getattr(slab, "shift", None):
-                name += "_{:.3f}".format(slab.shift)
+                name += "_{:.3f}".format(slab.shift).replace(".",",")
             name += " slab optimization"
 
             slab_data = {'miller_index': slab.miller_index,

--- a/atomate/vasp/firetasks/adsorption_tasks.py
+++ b/atomate/vasp/firetasks/adsorption_tasks.py
@@ -514,11 +514,12 @@ class SlabAdditionTask(FiretaskBase):
                 slab_fws.append(nscf_calc)
             else:
                 slab_fws.append(slab_fw)
-        if dos_calculate:
-            wf = Workflow(slab_fws)
-            return FWAction(additions=wf)
-        else:
-            return FWAction(additions=slab_fws)
+        wf = Workflow(slab_fws)
+        if slab_fw_params.get("calc_locs"):
+            from atomate.vasp.powerups import use_fake_vasp as fv
+            wf = fv(wf,{slab_fw.name:slab_fw_params.get("calc_locs")})
+
+        return FWAction(additions=wf)
 
 
 @explicit_serialize

--- a/atomate/vasp/firetasks/adsorption_tasks.py
+++ b/atomate/vasp/firetasks/adsorption_tasks.py
@@ -517,7 +517,7 @@ class SlabAdditionTask(FiretaskBase):
         wf = Workflow(slab_fws)
         if slab_fw_params.get("calc_locs"):
             from atomate.vasp.powerups import use_fake_vasp as fv
-            wf = fv(wf,{slab_fw.name:slab_fw_params.get("calc_locs")})
+            wf = fv(wf,slab_fw_params.get("calc_locs"))
 
         return FWAction(additions=wf)
 

--- a/atomate/vasp/firetasks/adsorption_tasks.py
+++ b/atomate/vasp/firetasks/adsorption_tasks.py
@@ -159,7 +159,7 @@ class LaunchVaspFromOptimumDistance(FiretaskBase):
                                          parents=slab_ads_fws[-1],
                                          vasptodb_kwargs={
                                              "task_fields_to_push": {
-                                                 "slab_structure":
+                                                 "slab_ads_structure":
                                                      "output.structure",
                                                  "slab_energy":
                                                      "output.energy"}},
@@ -1003,7 +1003,7 @@ class AnalysisAdditionTask(FiretaskBase):
         import atomate.vasp.fireworks.adsorption as af
 
         try:
-            output_slab_ads = Structure.from_dict(fw_spec["slab_ads_structure"])
+            output_slab_ads = Structure.from_dict(fw_spec[""])
         except TypeError:
             output_slab_ads = fw_spec["slab_ads_structure"]
         slab_ads_energy = fw_spec["slab_ads_energy"]

--- a/atomate/vasp/firetasks/adsorption_tasks.py
+++ b/atomate/vasp/firetasks/adsorption_tasks.py
@@ -375,6 +375,10 @@ class SlabAdditionTask(FiretaskBase):
         if calc_locs:
             bulk_dir = calc_locs[-1].get("path")
 
+        vasp_calcs = slab_fw_params.get("vasp_calcs")
+        if vasp_calcs:
+            slab_fw_params.pop("vasp_calcs")
+
         optimize_distance = self.get("optimize_distance")
         static_distances = self.get("static_distances")
         static_fws_params = self.get("static_fws_params")
@@ -515,9 +519,9 @@ class SlabAdditionTask(FiretaskBase):
             else:
                 slab_fws.append(slab_fw)
         wf = Workflow(slab_fws)
-        if slab_fw_params.get("calc_locs"):
+        if vasp_calcs:
             from atomate.vasp.powerups import use_fake_vasp as fv
-            wf = fv(wf,slab_fw_params.get("calc_locs"))
+            wf = fv(wf,vasp_calcs)
 
         return FWAction(additions=wf)
 

--- a/atomate/vasp/fireworks/adsorption.py
+++ b/atomate/vasp/fireworks/adsorption.py
@@ -288,7 +288,7 @@ class SlabFW(Firework):
                  user_incar_settings=None, optimize_distance=True,
                  static_distances=None,static_fws_params=None,
                  dos_calculate=True, bulk_data=None,
-                 slab_data=None, parents=None, **kwargs):
+                 slab_data=None, parents=None, calc_locs=None, **kwargs):
         """
         Optimize slab structure and add a slab + adsorbate generator
         firework as addition.

--- a/atomate/vasp/fireworks/adsorption.py
+++ b/atomate/vasp/fireworks/adsorption.py
@@ -16,6 +16,7 @@ from atomate.vasp.firetasks.parse_outputs import VaspToDb
 from atomate.vasp.firetasks.run_calc import RunVaspCustodian
 from atomate.vasp.firetasks.write_inputs import WriteVaspFromIOSet
 from atomate.vasp.fireworks import OptimizeFW
+from atomate.vasp.powerups import use_fake_vasp
 from fireworks import Firework
 from pymatgen.core import Molecule, Structure
 from pymatgen.io.vasp.sets import MPSurfaceSet, MPStaticSet
@@ -246,6 +247,7 @@ class BulkFW(Firework):
                               or {'IBRION': 2, 'POTIM': 0.5, 'NSW': 200,
                                   "IVDW": 11, "GGA": "RP", "EDIFFG":-.005}
 
+
         vis = vasp_input_set or MPSurfaceSet(
             bulk_structure, bulk=True, user_incar_settings=user_incar_settings)
 
@@ -257,6 +259,10 @@ class BulkFW(Firework):
                              db_file=db_file, job_type=job_type,
                              handler_group=handler_group,
                              vasptodb_kwargs=vasptodb_kwargs)
+
+        if kwargs.get("calc_loc"):
+            bulk_fw = use_fake_vasp(bulk_fw,{bulk_fw.name:kwargs.get("calc_loc")})
+
         t = bulk_fw.tasks
 
         add_fw_name = (bulk_structure.composition.reduced_formula

--- a/atomate/vasp/fireworks/adsorption.py
+++ b/atomate/vasp/fireworks/adsorption.py
@@ -188,7 +188,7 @@ class BulkFW(Firework):
                  ads_site_finder_params=None, ads_structures_params=None,
                  slab_ads_fw_params=None, optimize_distance=True,
                  static_distances=None, static_fws_params=None,
-                 dos_calculate=None,parents=None,calc_loc=None,**kwargs):
+                 dos_calculate=None,parents=None,**kwargs):
         """
         Optimize bulk structure and add a slab generator firework as
         addition.
@@ -288,7 +288,7 @@ class SlabFW(Firework):
                  user_incar_settings=None, optimize_distance=True,
                  static_distances=None,static_fws_params=None,
                  dos_calculate=True, bulk_data=None,
-                 slab_data=None, parents=None, calc_locs=None, **kwargs):
+                 slab_data=None, parents=None, **kwargs):
         """
         Optimize slab structure and add a slab + adsorbate generator
         firework as addition.

--- a/atomate/vasp/fireworks/adsorption.py
+++ b/atomate/vasp/fireworks/adsorption.py
@@ -16,7 +16,6 @@ from atomate.vasp.firetasks.parse_outputs import VaspToDb
 from atomate.vasp.firetasks.run_calc import RunVaspCustodian
 from atomate.vasp.firetasks.write_inputs import WriteVaspFromIOSet
 from atomate.vasp.fireworks import OptimizeFW
-from atomate.vasp.powerups import use_fake_vasp
 from fireworks import Firework
 from pymatgen.core import Molecule, Structure
 from pymatgen.io.vasp.sets import MPSurfaceSet, MPStaticSet
@@ -189,7 +188,7 @@ class BulkFW(Firework):
                  ads_site_finder_params=None, ads_structures_params=None,
                  slab_ads_fw_params=None, optimize_distance=True,
                  static_distances=None, static_fws_params=None,
-                 dos_calculate=None,parents=None,**kwargs):
+                 dos_calculate=None,parents=None,calc_loc=None,**kwargs):
         """
         Optimize bulk structure and add a slab generator firework as
         addition.
@@ -259,9 +258,6 @@ class BulkFW(Firework):
                              db_file=db_file, job_type=job_type,
                              handler_group=handler_group,
                              vasptodb_kwargs=vasptodb_kwargs)
-
-        if kwargs.get("calc_loc"):
-            bulk_fw = use_fake_vasp(bulk_fw,{bulk_fw.name:kwargs.get("calc_loc")})
 
         t = bulk_fw.tasks
 

--- a/atomate/vasp/workflows/base/adsorption.py
+++ b/atomate/vasp/workflows/base/adsorption.py
@@ -19,6 +19,7 @@ from pymatgen.analysis.adsorption import AdsorbateSiteFinder
 from pymatgen.core.surface import generate_all_slabs, Slab
 from pymatgen.transformations.advanced_transformations import SlabTransformation
 from pymatgen.transformations.standard_transformations import SupercellTransformation
+from atomate.vasp.powerups import use_fake_vasp
 from pymatgen.io.vasp.sets import MVLSlabSet, MPStaticSet
 from pymatgen.io.vasp.inputs import Kpoints
 from pymatgen.io.vasp.sets import MPSurfaceSet
@@ -428,6 +429,8 @@ def get_wf_from_bulk(bulk_structure, adsorbates=None, vasp_cmd=VASP_CMD,
         name += " {}".format(ads_name)
     name += " adsorption wf"
     wf = Workflow(fws, name=name)
+    if bulk_fw_params.get("calc_loc"):
+        wf = use_fake_vasp(wf,{wf.fws[0].name: bulk_fw_params.get("calc_loc")})
     # TODO: add_molecules_in_box
 
     return wf

--- a/atomate/vasp/workflows/base/adsorption.py
+++ b/atomate/vasp/workflows/base/adsorption.py
@@ -429,8 +429,9 @@ def get_wf_from_bulk(bulk_structure, adsorbates=None, vasp_cmd=VASP_CMD,
         name += " {}".format(ads_name)
     name += " adsorption wf"
     wf = Workflow(fws, name=name)
-    if bulk_fw_params.get("calc_loc"):
-        wf = use_fake_vasp(wf,{wf.fws[0].name: bulk_fw_params.get("calc_loc")})
+    if bulk_fw_params.get("vasp_calc"):
+        vasp_calc = bulk_fw_params.pop("vasp_calc")
+        wf = use_fake_vasp(wf,{wf.fws[0].name: vasp_calc})
     # TODO: add_molecules_in_box
 
     return wf


### PR DESCRIPTION
## Summary
Ability to pass already calculated folders into WF by using the run_fake_vasp powerup. Replacing "." with "," FW name to prevent downstream errors with MongoDB